### PR TITLE
Report collider parts in OnSeparate, return void from OnSeparate and OnCollide

### DIFF
--- a/include/Scroll/ScrollBase.inl
+++ b/include/Scroll/ScrollBase.inl
@@ -1632,7 +1632,6 @@ orxSTATUS orxFASTCALL ScrollBase::StaticEventHandler(const orxEVENT *_pstEvent)
       {
         orxPHYSICS_EVENT_PAYLOAD *pstPayload;
         ScrollObject             *poSender, *poRecipient;
-        orxBOOL                   bContinue = orxTRUE;
 
         // Gets payload
         pstPayload = (orxPHYSICS_EVENT_PAYLOAD *)_pstEvent->pstPayload;
@@ -1653,17 +1652,17 @@ orxSTATUS orxFASTCALL ScrollBase::StaticEventHandler(const orxEVENT *_pstEvent)
           if(_pstEvent->eID == orxPHYSICS_EVENT_CONTACT_ADD)
           {
             // Calls its callback
-            bContinue = poSender->OnCollide(poRecipient, pstPayload->pstSenderPart, pstPayload->pstRecipientPart, pstPayload->vPosition, vNormal);
+            poSender->OnCollide(poRecipient, pstPayload->pstSenderPart, pstPayload->pstRecipientPart, pstPayload->vPosition, vNormal);
           }
           else
           {
             // Calls its callback
-            bContinue = poSender->OnSeparate(poRecipient);
+            poSender->OnSeparate(poRecipient, pstPayload->pstSenderPart, pstPayload->pstRecipientPart);
           }
         }
 
         // Is recipient valid?
-        if(bContinue && poRecipient)
+        if(poRecipient)
         {
           // New collision?
           if(_pstEvent->eID == orxPHYSICS_EVENT_CONTACT_ADD)
@@ -1674,7 +1673,7 @@ orxSTATUS orxFASTCALL ScrollBase::StaticEventHandler(const orxEVENT *_pstEvent)
           else
           {
             // Calls its callback
-            poRecipient->OnSeparate(poSender);
+            poRecipient->OnSeparate(poSender, pstPayload->pstRecipientPart, pstPayload->pstSenderPart);
           }
         }
       }

--- a/include/Scroll/ScrollObject.h
+++ b/include/Scroll/ScrollObject.h
@@ -133,8 +133,8 @@ private:
   virtual       orxBOOL                 OnRender(orxRENDER_EVENT_PAYLOAD &_rstPayload);
   virtual       orxBOOL                 OnShader(orxSHADER_EVENT_PAYLOAD &_rstPayload);
 
-  virtual       orxBOOL                 OnCollide(ScrollObject *_poCollider, orxBODY_PART *_pstPart, orxBODY_PART *_pstColliderPart, const orxVECTOR &_rvPosition, const orxVECTOR &_rvNormal);
-  virtual       orxBOOL                 OnSeparate(ScrollObject *_poCollider);
+  virtual       void                    OnCollide(ScrollObject *_poCollider, orxBODY_PART *_pstPart, orxBODY_PART *_pstColliderPart, const orxVECTOR &_rvPosition, const orxVECTOR &_rvNormal);
+  virtual       void                    OnSeparate(ScrollObject *_poCollider, orxBODY_PART *_pstPart, orxBODY_PART *_pstColliderPart);
 
   virtual       void                    OnNewAnim(const orxSTRING _zOldAnim, const orxSTRING _zNewAnim, orxBOOL _bCut);
   virtual       void                    OnAnimUpdate(const orxSTRING _zAnim);

--- a/include/Scroll/ScrollObject.inl
+++ b/include/Scroll/ScrollObject.inl
@@ -624,14 +624,12 @@ void ScrollObject::Update(const orxCLOCK_INFO &_rstInfo)
 {
 }
 
-orxBOOL ScrollObject::OnCollide(ScrollObject *_poCollider, orxBODY_PART *_pstPart, orxBODY_PART *_pstColliderPart, const orxVECTOR &_rvPosition, const orxVECTOR &_rvNormal)
+void ScrollObject::OnCollide(ScrollObject *_poCollider, orxBODY_PART *_pstPart, orxBODY_PART *_pstColliderPart, const orxVECTOR &_rvPosition, const orxVECTOR &_rvNormal)
 {
-  return orxTRUE;
 }
 
-orxBOOL ScrollObject::OnSeparate(ScrollObject *_poCollider)
+void ScrollObject::OnSeparate(ScrollObject *_poCollider, orxBODY_PART *_pstPart, orxBODY_PART *_pstColliderPart)
 {
-  return orxTRUE;
 }
 
 void ScrollObject::OnNewAnim(const orxSTRING _zOldAnim, const orxSTRING _zNewAnim, orxBOOL _bCut)


### PR DESCRIPTION
Discord discussion link: https://discord.com/channels/522167736823185418/721593711204630580/1119649574043267154

I did not include the position or normal arguments for `OnSeparate` because they are set to zero length vectors in the existing physics plugin. I'm happy to add those if you'd prefer for future proofing.

From the commit message:

Reporting collider parts in OnSeparate allows objects to track which parts they lose contact with for a specific object. An example of where this may be useful is detecting when separation occurs with a non-solid sensor part versus a solid body part.

OnSeparate and OnCollide used to return orxBOOL as way to prevent the other collider's callback from being called. However the callback order can not be controlled from orx so this simplifies the API by changing the return value from orxBOOL to void. With this change both colliders, if they are Scroll objects, will have their OnSeparate and OnCollide callbacks called.